### PR TITLE
Update docker/root documentation - closes #686

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -281,8 +281,9 @@ And run tests:
 Running on Docker/as root
 =========================
 
-Unfortunately, running MySQL as root (thus by default on docker) is not possible.
-MySQL (and MariaDB as well) will not allow it.
+MySQL and MariaDB refuse to run as root by default, but we can force them by setting user=root in the configuration file.
+
+However most common and secure approach is to change user which runs tests on Docker:
 
 .. code-block::
 

--- a/newsfragments/686.misc.rst
+++ b/newsfragments/686.misc.rst
@@ -1,0 +1,1 @@
+Update Docker/root related part of README


### PR DESCRIPTION
Chore that needs to be done:

* [x] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_numer either from issue tracker or the Pull request number.
