### PR TITLE
Add zizmor to pre-commit - closes #826

### DIFF
--- a/.github/workflows/tests-macosx.yml
+++ b/.github/workflows/tests-macosx.yml
@@ -24,8 +24,10 @@ jobs:
       OS: macos-latest
       PYTHON: ${{ matrix.python-version }}
     steps:
-    - uses: actions/checkout@v7
-    - uses: ankane/setup-mysql@v1
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
+    - uses: ankane/setup-mysql@v1 # zizmor: ignore[unpinned-uses]
       with:
         mysql-version: 8.4
     - name: Check MySQL Version
@@ -44,7 +46,7 @@ jobs:
         output-file: coverage-serial.xml
     - name: Upload coverage to Codecov
       if: ${{ always() }}
-      uses: codecov/codecov-action@v6.0.0
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6.0.2
       with:
         files: coverage-serial.xml
         flags: macos,mysql
@@ -62,8 +64,10 @@ jobs:
       OS: macos-latest
       PYTHON: ${{ matrix.python-version }}
     steps:
-    - uses: actions/checkout@v7
-    - uses: ankane/setup-mariadb@v1
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
+    - uses: ankane/setup-mariadb@v1 # zizmor: ignore[unpinned-uses]
       with:
         mariadb-version: "11.4"
     - name: Check MySQL Version
@@ -80,7 +84,7 @@ jobs:
         output-file: coverage-serial.xml
     - name: Upload coverage to Codecov
       if: ${{ always() }}
-      uses: codecov/codecov-action@v6.0.0
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6.0.2
       with:
         files: coverage-serial.xml
         flags: macos,mariadb

--- a/.github/workflows/tests-mariadb-linux.yml
+++ b/.github/workflows/tests-mariadb-linux.yml
@@ -38,8 +38,10 @@ jobs:
         options: --health-cmd="healthcheck.sh --su-mysql --connect --innodb_initialized" --health-interval=10s --health-timeout=5s --health-retries=3
 
     steps:
-      - uses: actions/checkout@v7
-      - uses: ankane/setup-mariadb@v1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ankane/setup-mariadb@v1 # zizmor: ignore[unpinned-uses]
         with:
           mariadb-version: ${{ inputs.mariadb }}
       - name: Check MariaDB Version
@@ -70,7 +72,7 @@ jobs:
           output-file: coverage-noproc.xml
       - name: Upload coverage to Codecov
         if: ${{ always() }}
-        uses: codecov/codecov-action@v6.0.0
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6.0.2
         with:
           files: coverage-serial.xml,coverage-xdist.xml,coverage-noproc.xml
           flags: linux,mariadb

--- a/.github/workflows/tests-mysql-linux.yml
+++ b/.github/workflows/tests-mysql-linux.yml
@@ -38,8 +38,10 @@ jobs:
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
 
     steps:
-      - uses: actions/checkout@v7
-      - uses: ankane/setup-mysql@v1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ankane/setup-mysql@v1 # zizmor: ignore[unpinned-uses]
         with:
           mysql-version: ${{ inputs.mysql }}
       - name: Check MySQL Version
@@ -69,7 +71,7 @@ jobs:
           data-file: .coverage.noproc
           output-file: coverage-noproc.xml
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v6.0.0
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6.0.2
         with:
           files: coverage-serial.xml,coverage-xdist.xml,coverage-noproc.xml
           flags: linux,mysql

--- a/.github/workflows/tests-oldest.yml
+++ b/.github/workflows/tests-oldest.yml
@@ -35,8 +35,10 @@ jobs:
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
 
     steps:
-      - uses: actions/checkout@v7
-      - uses: ankane/setup-mysql@v1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ankane/setup-mysql@v1 # zizmor: ignore[unpinned-uses]
         with:
           mysql-version: "8.4"
       - name: Check MySQL Version
@@ -70,7 +72,7 @@ jobs:
           data-file: .coverage.noproc
           output-file: coverage-noproc.xml
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v6.0.0
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6.0.2
         with:
           files: coverage-serial.xml,coverage-xdist.xml,coverage-noproc.xml
           flags: linux,mysql
@@ -98,8 +100,10 @@ jobs:
         options: --health-cmd="healthcheck.sh --su-mysql --connect --innodb_initialized" --health-interval=10s --health-timeout=5s --health-retries=3
 
     steps:
-      - uses: actions/checkout@v7
-      - uses: ankane/setup-mariadb@v1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ankane/setup-mariadb@v1 # zizmor: ignore[unpinned-uses]
         with:
           mariadb-version: "10.11"
       - name: Check MariaDB Version
@@ -134,7 +138,7 @@ jobs:
           output-file: coverage-noproc.xml
       - name: Upload coverage to Codecov
         if: ${{ always() }}
-        uses: codecov/codecov-action@v6.0.0
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6.0.2
         with:
           files: coverage-serial.xml,coverage-xdist.xml,coverage-noproc.xml
           flags: linux,mariadb

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions: {}
+
 jobs:
   tests-mysql-linux:
     uses: ./.github/workflows/tests-mysql-linux.yml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,6 +38,17 @@ repos:
       - id: rstcheck
         additional_dependencies: [sphinx, toml]
 
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: v1.29.0
+    hooks:
+      - id: zizmor
+        args: [--no-progress, --fix]
+
+  - repo: https://github.com/kjanat/actionlint
+    rev: v1.14.0
+    hooks:
+      - id: actionlint
+
   - repo: https://github.com/tox-dev/pyproject-fmt
     rev: v2.28.1
     hooks:

--- a/newsfragments/826.misc.rst
+++ b/newsfragments/826.misc.rst
@@ -1,0 +1,1 @@
+Add zizmor to pre-commit and harden GitHub Actions workflow permissions.

--- a/newsfragments/842.misc.rst
+++ b/newsfragments/842.misc.rst
@@ -1,0 +1,1 @@
+Add actionlint to pre-commit


### PR DESCRIPTION
  * Add actionlint to pre-commit - closes #842

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Hardened GitHub Actions workflows by restricting default token permissions and disabling persisted checkout credentials.
  - Pinned key workflow actions to specific versions for more predictable and secure automated testing.
  - Added security and workflow validation checks to pre-commit configuration.
  - Documented the updated workflow security and validation measures in the changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->