### PR TITLE
Enable FBT ruff rulestet - closes #830

### DIFF
--- a/newsfragments/830.misc.rst
+++ b/newsfragments/830.misc.rst
@@ -1,0 +1,1 @@
+Enable FBT ruff ruleset

--- a/newsfragments/837.misc.rst
+++ b/newsfragments/837.misc.rst
@@ -1,0 +1,1 @@
+Enable the PT Ruff ruleset and update pytest annotations and parametrisation to satisfy it.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,9 @@ select = [
     "F",    # pyflakes
     "I",    # isort
     "D",    # pydocstyle
-    "S602"
+    "S602",
+    "FBT",  # flake8-boolean-trap
+    "PT",   # flake8-pytest-style
 ]
 
 [tool.pyproject-fmt]

--- a/pytest_mysql/config.py
+++ b/pytest_mysql/config.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from pytest import FixtureRequest
+import pytest
 
 
 @dataclass
@@ -24,7 +24,7 @@ class MySQLConfig:
     install_db: str
 
 
-def get_config(request: FixtureRequest) -> MySQLConfig:
+def get_config(request: pytest.FixtureRequest) -> MySQLConfig:
     """Return a pytest-mtsql config options."""
 
     def get_conf_option(option: str) -> Any:

--- a/pytest_mysql/factories/process.py
+++ b/pytest_mysql/factories/process.py
@@ -22,7 +22,6 @@ from typing import Callable, Generator, Iterable
 
 import pytest
 from port_for import PortForException, PortType, get_port
-from pytest import FixtureRequest, TempPathFactory
 
 from pytest_mysql.config import MySQLConfig, get_config
 from pytest_mysql.executor import MySQLExecutor
@@ -44,7 +43,9 @@ def mysql_proc(
     port: PortType | None = -1,
     params: str | None = None,
     install_db: str | None = None,
-) -> Callable[[FixtureRequest, TempPathFactory], Generator[MySQLExecutor, None, None]]:
+) -> Callable[
+    [pytest.FixtureRequest, pytest.TempPathFactory], Generator[MySQLExecutor, None, None]
+]:
     """Process fixture factory for MySQL server.
 
     :param mysqld_exec: path to mysql executable
@@ -66,7 +67,7 @@ def mysql_proc(
 
     @pytest.fixture(scope="session")
     def mysql_proc_fixture(
-        request: FixtureRequest, tmp_path_factory: TempPathFactory
+        request: pytest.FixtureRequest, tmp_path_factory: pytest.TempPathFactory
     ) -> Generator[MySQLExecutor, None, None]:
         """Process fixture for MySQL server.
 

--- a/pytest_mysql/plugin.py
+++ b/pytest_mysql/plugin.py
@@ -17,7 +17,7 @@
 # along with pytest-mysql.  If not, see <http://www.gnu.org/licenses/>.
 """Plugin definition."""
 
-from pytest import Parser
+import pytest
 
 from pytest_mysql import factories
 
@@ -36,7 +36,7 @@ _help_dbname = "Test database name"
 _help_params = "Starting parameters for the MySQL"
 
 
-def pytest_addoption(parser: Parser) -> None:
+def pytest_addoption(parser: pytest.Parser) -> None:
     """Plugin configuration."""
     parser.addini(name="mysql_mysqld", help=_help_mysqld, default="mysqld")
     parser.addoption(

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -4,15 +4,14 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
-from pytest import TempPathFactory
 
 from pytest_mysql.exceptions import MySQLUnsupported
 from pytest_mysql.executor import MySQLExecutor
 
 
 @pytest.mark.parametrize(
-    "verstr, version",
-    (
+    ("verstr", "version"),
+    [
         (b"mysql_install_db Ver 5.7.21, for Linux on x86_64", "5.7.21"),
         (
             (b"mysqld  Ver 5.7.21-0ubuntu0.17.10.1 for Linux on x86_64 ((Ubuntu))"),
@@ -32,9 +31,11 @@ from pytest_mysql.executor import MySQLExecutor
         ),
         ((b"mysqld  Ver 5.7.23 for osx10.13 on x86_64 (Homebrew)"), "5.7.23"),
         ((b"\nmysqld  Ver 5.7.23 for osx10.13 on x86_64 (Homebrew)"), "5.7.23"),
-    ),
+    ],
 )
-def test_version_check(verstr: bytes, version: str, tmp_path_factory: TempPathFactory) -> None:
+def test_version_check(
+    verstr: bytes, version: str, tmp_path_factory: pytest.TempPathFactory
+) -> None:
     """Test executor's version property."""
     executor = MySQLExecutor(
         mysqld_safe=Path(""),
@@ -53,8 +54,8 @@ def test_version_check(verstr: bytes, version: str, tmp_path_factory: TempPathFa
 
 
 @pytest.mark.parametrize(
-    "verstr, implementation",
-    (
+    ("verstr", "implementation"),
+    [
         (b"mysql_install_db Ver 5.7.21, for Linux on x86_64", "mysql"),
         (
             (b"mysqld  Ver 5.7.21-0ubuntu0.17.10.1 for Linux on x86_64 ((Ubuntu))"),
@@ -78,10 +79,10 @@ def test_version_check(verstr: bytes, version: str, tmp_path_factory: TempPathFa
             (b"mysqld  Ver 5.7.23 for osx10.13 on x86_64 (Homebrew)"),
             "mysql",
         ),
-    ),
+    ],
 )
 def test_implementation(
-    verstr: bytes, implementation: str, tmp_path_factory: TempPathFactory
+    verstr: bytes, implementation: str, tmp_path_factory: pytest.TempPathFactory
 ) -> None:
     """Check detecting implementation."""
     executor = MySQLExecutor(
@@ -102,7 +103,7 @@ def test_implementation(
 
 @pytest.mark.parametrize(
     "verstr",
-    (
+    [
         b"mysql_install_db Ver 5.7.1, for Linux on x86_64",
         b"mysqld  Ver 5.7.1-0ubuntu0.17.10.1 for Linux on x86_64 ((Ubuntu))",
         b"mysql 5.5.55",
@@ -110,9 +111,9 @@ def test_implementation(
             b"mysqld  Ver 10.1.30-MariaDB-0ubuntu0.17.10.1 "
             b"for debian-linux-gnu on x86_64 (Ubuntu 17.10)"
         ),
-    ),
+    ],
 )
-def test_exception_raised(verstr: bytes, tmp_path_factory: TempPathFactory) -> None:
+def test_exception_raised(verstr: bytes, tmp_path_factory: pytest.TempPathFactory) -> None:
     """Raise exception on not supported versions."""
     executor = MySQLExecutor(
         mysqld_safe=Path(""),


### PR DESCRIPTION
Enable PT ruff rulesets - closes #837

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Enabled Ruff’s FBT and PT linting rulesets.
  - Updated code and tests to comply with the newly enabled linting rules.

- **Style**
  - Standardised pytest type annotations and import usage.
  - Reformatted test parameterisation for improved consistency and readability.

- **Documentation**
  - Added release notes documenting the enabled linting rulesets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->