### PR TITLE
Update MariaDB and MySQL in CI - closes #785

### DIFF
--- a/.github/workflows/tests-macosx.yml
+++ b/.github/workflows/tests-macosx.yml
@@ -27,9 +27,9 @@ jobs:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
-    - uses: ankane/setup-mysql@v1 # zizmor: ignore[unpinned-uses]
+    - uses: ankane/setup-mysql@19fbb7ee54446ac7f3aed34db192ec70dbec6092 # v1
       with:
-        mysql-version: 8.4
+        mysql-version: 9.7
     - name: Check MySQL Version
       run: mysqld --version
     - name: Set up uv with python ${{ matrix.python-version }}
@@ -67,9 +67,9 @@ jobs:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
-    - uses: ankane/setup-mariadb@v1 # zizmor: ignore[unpinned-uses]
+    - uses: ankane/setup-mariadb@e34d4859081a8192918ea2302b7c9a71475a0d73 # v1
       with:
-        mariadb-version: "11.4"
+        mariadb-version: "12.3"
     - name: Check MySQL Version
       run: mysqld --version
     - name: Set up uv with python ${{ matrix.python-version }}

--- a/.github/workflows/tests-mariadb-linux.yml
+++ b/.github/workflows/tests-mariadb-linux.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: ankane/setup-mariadb@v1 # zizmor: ignore[unpinned-uses]
+      - uses: ankane/setup-mariadb@e34d4859081a8192918ea2302b7c9a71475a0d73 # v1
         with:
           mariadb-version: ${{ inputs.mariadb }}
       - name: Check MariaDB Version

--- a/.github/workflows/tests-mysql-linux.yml
+++ b/.github/workflows/tests-mysql-linux.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: ankane/setup-mysql@v1 # zizmor: ignore[unpinned-uses]
+      - uses: ankane/setup-mysql@19fbb7ee54446ac7f3aed34db192ec70dbec6092 # v1
         with:
           mysql-version: ${{ inputs.mysql }}
       - name: Check MySQL Version

--- a/.github/workflows/tests-oldest.yml
+++ b/.github/workflows/tests-oldest.yml
@@ -26,7 +26,7 @@ jobs:
       UV_NO_SYNC: "1"
     services:
       mysql:
-        image: mysql:8.4
+        image: mysql:9.7
         env:
           MYSQL_ALLOW_EMPTY_PASSWORD: yes
           MYSQL_DATABASE: tests
@@ -38,9 +38,9 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: ankane/setup-mysql@v1 # zizmor: ignore[unpinned-uses]
+      - uses: ankane/setup-mysql@19fbb7ee54446ac7f3aed34db192ec70dbec6092 # v1
         with:
-          mysql-version: "8.4"
+          mysql-version: "9.7"
       - name: Check MySQL Version
         run: mysqld --version
       - name: Set up uv with python ${{ matrix.python-version }}
@@ -91,7 +91,7 @@ jobs:
       PYTHON: ${{ matrix.python-version }}
     services:
       mysql:
-        image: mariadb:10.11
+        image: mariadb:12.3
         env:
           MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: yes
           MARIADB_DATABASE: tests
@@ -103,9 +103,9 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: ankane/setup-mariadb@v1 # zizmor: ignore[unpinned-uses]
+      - uses: ankane/setup-mariadb@e34d4859081a8192918ea2302b7c9a71475a0d73 # v1 #
         with:
-          mariadb-version: "10.11"
+          mariadb-version: "12.3"
       - name: Check MariaDB Version
         run: mysqld --version
       - name: Set up uv with python ${{ matrix.python-version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,16 +9,25 @@ on:
 permissions: {}
 
 jobs:
-  tests-mysql-linux:
+  tests-mysql-linux_9_7:
     uses: ./.github/workflows/tests-mysql-linux.yml
     with:
-      mysql: "8.4"
+      mysql: "9.7"
       python-versions: '["3.10", "3.11", "3.12", "3.13", "3.14", "pypy-3.11"]'
     secrets:
       codecov_token: ${{ secrets.CODECOV_TOKEN }}
 
+  tests-mysql-linux_8_4:
+    needs: [ tests-mysql-linux_9_7 ]
+    uses: ./.github/workflows/tests-mysql-linux.yml
+    with:
+      mysql: "8.4"
+      python-versions: '["3.12", "3.13", "3.14", "pypy-3.11"]'
+    secrets:
+      codecov_token: ${{ secrets.CODECOV_TOKEN }}
+
   tests-mysql-linux_8:
-    needs: [ tests-mysql-linux ]
+    needs: [ tests-mysql-linux_8_4 ]
     uses: ./.github/workflows/tests-mysql-linux.yml
     with:
       mysql: "8.0"
@@ -26,8 +35,26 @@ jobs:
     secrets:
       codecov_token: ${{ secrets.CODECOV_TOKEN }}
 
-  tests-mariadb-linux-11:
-    needs: [ tests-mysql-linux ]
+  tests-mariadb-linux-12_3:
+    needs: [ tests-mysql-linux_9_7 ]
+    uses: ./.github/workflows/tests-mariadb-linux.yml
+    with:
+      mariadb: "12.3"
+      python-versions: '["3.12", "3.13", "3.14"]'
+    secrets:
+      codecov_token: ${{ secrets.CODECOV_TOKEN }}
+
+  tests-mariadb-linux-11_8:
+    needs: [ tests-mariadb-linux-12_3 ]
+    uses: ./.github/workflows/tests-mariadb-linux.yml
+    with:
+      mariadb: "11.8"
+      python-versions: '["3.12", "3.13", "3.14"]'
+    secrets:
+      codecov_token: ${{ secrets.CODECOV_TOKEN }}
+
+  tests-mariadb-linux-11_4:
+    needs: [ tests-mariadb-linux-11_8 ]
     uses: ./.github/workflows/tests-mariadb-linux.yml
     with:
       mariadb: "11.4"
@@ -36,7 +63,7 @@ jobs:
       codecov_token: ${{ secrets.CODECOV_TOKEN }}
 
   tests-mariadb-linux-10_11:
-    needs: [ tests-mariadb-linux-11 ]
+    needs: [ tests-mariadb-linux-11_4 ]
     uses: ./.github/workflows/tests-mariadb-linux.yml
     with:
       mariadb: 10.11
@@ -45,7 +72,7 @@ jobs:
       codecov_token: ${{ secrets.CODECOV_TOKEN }}
 
   tests-oldest:
-    needs: [ tests-mariadb-linux-11 ]
+    needs: [ tests-mariadb-linux-10_11, tests-mysql-linux_8 ]
     uses: ./.github/workflows/tests-oldest.yml
     with:
       python-versions: '["3.10", "3.14"]'
@@ -53,7 +80,7 @@ jobs:
       codecov_token: ${{ secrets.CODECOV_TOKEN }}
 
   tests-macosx:
-    needs: [tests-mysql-linux]
+    needs: [tests-mariadb-linux-12_3, tests-mysql-linux_9_7]
     uses: ./.github/workflows/tests-macosx.yml
     secrets:
       codecov_token: ${{ secrets.CODECOV_TOKEN }}

--- a/newsfragments/785.misc.1.rst
+++ b/newsfragments/785.misc.1.rst
@@ -1,0 +1,1 @@
+Add MySQL 9.7 to CI

--- a/newsfragments/785.misc.rst
+++ b/newsfragments/785.misc.rst
@@ -1,0 +1,1 @@
+Add MariaDB 11.8 and 12.3 to CI

--- a/newsfragments/860.misc.rst
+++ b/newsfragments/860.misc.rst
@@ -1,0 +1,1 @@
+Pin both `ankane/setup-mysql` and `ankane/setup-mariadb` to a commit hash


### PR DESCRIPTION
Pin both setup-mysql and setup-mariadb  by hash - closes #860

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added CI coverage for MySQL 9.7 and MariaDB 11.8 and 12.8.
  - Retained dedicated testing for earlier supported MySQL and MariaDB versions.

- **Chores**
  - Pinned database setup actions to specific revisions, improving workflow reproducibility and security.
  - Updated database service versions used in automated testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->