### PR TITLE
Waith for mysqld's unix socket to accept connections - closes #871

### DIFF
--- a/newsfragments/871.bugfix.rst
+++ b/newsfragments/871.bugfix.rst
@@ -1,0 +1,5 @@
+Wait for mysqld's unix socket to accept connections before considering the server
+started.
+Previously executor only checked the TCP port, which mysqld starts listening on
+before it creates the socket, so client fixtures could connect too early and fail
+with ``(2003, "Can't connect to MySQL server on 'localhost' ([Errno 2] No such file or directory)")``.

--- a/pytest_mysql/executor.py
+++ b/pytest_mysql/executor.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Any, Literal, Self
 
 from mirakuru import TCPExecutor
+from mirakuru.unixsocket import UnixSocketExecutor
 from packaging.version import parse
 
 from pytest_mysql.exceptions import (
@@ -75,6 +76,10 @@ class MySQLExecutor(TCPExecutor):
             f"--skip-syslog {params}"
         )
         super().__init__(command, host, port, timeout=timeout)
+        self._unixsocketexecutor = UnixSocketExecutor(
+            command, socket_name=self.unixsocket, timeout=timeout
+        )
+        """Never started, only its unix socket check is used by `after_start_check`."""
 
     def version(self) -> str:
         """Read MySQL's version."""
@@ -154,6 +159,15 @@ class MySQLExecutor(TCPExecutor):
         else:
             raise MySQLUnsupported("Only MySQL and MariaDB servers are supported with MariaDB.")
         return super().start()
+
+    def after_start_check(self) -> bool:
+        """Check if the server accepts connections on the port and the unix socket.
+
+        The TCP port starts accepting connections before mysqld creates the
+        unix socket, and the client fixtures connect through the socket, so
+        waiting for the port alone lets them connect too early.
+        """
+        return super().after_start_check() and self._unixsocketexecutor.pre_start_check()
 
     def shutdown(self) -> None:
         """Send shutdown command to the server."""

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -1,5 +1,7 @@
 """Executor tests."""
 
+import socket
+from contextlib import closing
 from pathlib import Path
 from unittest.mock import patch
 
@@ -132,3 +134,41 @@ def test_exception_raised(verstr: bytes, tmp_path_factory: pytest.TempPathFactor
         pytest.raises(MySQLUnsupported),
     ):
         executor.start()
+
+
+@pytest.mark.parametrize(
+    ("tcp_up", "socket_state", "started"),
+    [
+        (True, "listening", True),
+        (True, "stale", False),
+        (True, "missing", False),
+        (False, "listening", False),
+    ],
+)
+def test_after_start_check_waits_for_socket(
+    tcp_up: bool,  # noqa: FBT001
+    socket_state: str,
+    started: bool,  # noqa: FBT001
+    tmp_path_factory: pytest.TempPathFactory,
+) -> None:
+    """The server counts as started only once its unix socket accepts connections."""
+    executor = MySQLExecutor(
+        mysqld_safe=Path(""),
+        mysqld=Path(""),
+        admin_exec="",
+        logfile_path="",
+        params="",
+        base_directory=tmp_path_factory.mktemp("pytest-mysql"),
+        user="",
+        host="",
+        port=8838,
+    )
+    with closing(socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)) as listener:
+        if socket_state == "listening":
+            listener.bind(executor.unixsocket)
+            listener.listen(1)
+        elif socket_state == "stale":
+            Path(executor.unixsocket).touch()
+
+        with patch("mirakuru.TCPExecutor.after_start_check", lambda _self: tcp_up):
+            assert executor.after_start_check() is started


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - MySQL server startup now waits until both the TCP port and Unix socket accept connections.
  - Prevents clients and test fixtures from connecting prematurely and failing while the server is still starting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->